### PR TITLE
Removed idAgent field

### DIFF
--- a/src/pages/clients.js
+++ b/src/pages/clients.js
@@ -77,7 +77,6 @@ const Clients = () => {
 		var currentAgent = JSON.parse(atob(localStorage.getItem("user_details")))
 		console.log('Current Agent ID: ' + currentAgent.id_agent)
 		getClientsData(currentAgent.id_agent); //Modify this so that the value comes from localstorage
-		// getClientsData(1); //Modify this so that the value comes from localstorage
 	})
 	return (
 		<div>


### PR DESCRIPTION
The api request was correct and worked properly. Make sure to read the returned object. Specifically for the "success" flag. Since the user admin "id_agent = 7" has no clients, the table couldn't be populated, I added an if success = true, then fill table.

This was tested with the following branches:

Frontend: fix-clientUseEffect
Backend: development